### PR TITLE
Add circles around samples for pickup with extensions

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,9 +25,9 @@
   let lineWidth = 0.57;
   let robotWidth = 16;
   let robotHeight = 16;
+  let sampleCircleRadius: number | null = null;
 
   let percent: number = 0;
-
 
 
   /**
@@ -65,6 +65,11 @@
       color: getRandomColor(),
     },
   ];
+  let samplePoints: BasePoint[] = [
+    { x: 45.75, y: 23 },
+    { x: 45.75, y: 12.55 },
+    { x: 45.75, y: 2.12 }
+  ];
 
   $: points = (() => {
     let _points = [];
@@ -78,6 +83,20 @@
     startPointElem.noStroke();
 
     _points.push(startPointElem);
+
+    if(sampleCircleRadius !== null && sampleCircleRadius > 0) {
+      samplePoints.forEach((point, idx) => {
+        let samplePointElem = new Two.Circle(
+          x(point.x),
+          y(point.y),
+          x(sampleCircleRadius as number)
+        );
+        samplePointElem.id = `point-sample-${idx}`;
+        samplePointElem.fill = "transparent";
+        samplePointElem.stroke = "orange";
+        _points.push(samplePointElem);
+      });
+    }
 
     lines.forEach((line, idx) => {
       [line.endPoint, ...line.controlPoints].forEach((point, idx1) => {
@@ -533,6 +552,7 @@ hotkeys('s', function(event, handler){
     bind:lines
     bind:robotWidth
     bind:robotHeight
+    bind:sampleCircleRadius
     bind:percent
     bind:robotXY
     bind:robotHeading

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -65,10 +65,28 @@
       color: getRandomColor(),
     },
   ];
-  let samplePoints: BasePoint[] = [
+  let blueSamplePoints: BasePoint[] = [
+    // Specimen Side
     { x: 45.75, y: 23 },
     { x: 45.75, y: 12.55 },
-    { x: 45.75, y: 2.12 }
+    { x: 45.75, y: 2.12 },
+
+    //Basket Side
+    { x: 45.75, y: 121.3 },
+    { x: 45.75, y: 131.7 },
+    { x: 45.75, y: 142 },
+  ];
+
+  let redSamplePoints: BasePoint[] = [
+    // Specimen Side
+    { x: 98.25, y: 23 },
+    { x: 98.25, y: 12.55 },
+    { x: 98.25, y: 2.12 },
+
+    //Basket Side
+    { x: 98.25, y: 121.3 },
+    { x: 98.25, y: 131.7 },
+    { x: 98.25, y: 142 },
   ];
 
   $: points = (() => {
@@ -85,6 +103,8 @@
     _points.push(startPointElem);
 
     if(sampleCircleRadius !== null && sampleCircleRadius > 0) {
+      let samplePoints = allianceColor === "red" ? redSamplePoints : blueSamplePoints;
+
       samplePoints.forEach((point, idx) => {
         let samplePointElem = new Two.Circle(
           x(point.x),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -26,6 +26,7 @@
   let robotWidth = 16;
   let robotHeight = 16;
   let sampleCircleRadius: number | null = null;
+  let allianceColor: "blue" | "red" = "blue";
 
   let percent: number = 0;
 
@@ -573,6 +574,7 @@ hotkeys('s', function(event, handler){
     bind:robotWidth
     bind:robotHeight
     bind:sampleCircleRadius
+    bind:allianceColor
     bind:percent
     bind:robotXY
     bind:robotHeading

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -10,6 +10,7 @@
   export let lines: Line[];
   export let robotWidth: number;
   export let robotHeight: number;
+  export let sampleCircleRadius: number | null;
   export let robotXY: BasePoint;
   export let robotHeading: number;
   export let x: d3.ScaleLinear<number, number, number>;
@@ -36,6 +37,13 @@
           type="number"
           class="pl-1.5 rounded-md bg-neutral-100 border-[0.5px] focus:outline-none w-16 dark:bg-neutral-950 dark:border-neutral-700"
           step="1"
+        />
+        <div class="font-extralight">Sample Circle Radius:</div>
+        <input
+          bind:value={sampleCircleRadius}
+          type="number"
+          class="pl-1.5 rounded-md bg-neutral-100 border-[0.5px] focus:outline-none w-16 dark:bg-neutral-950 dark:border-neutral-700"
+          step="0.5"
         />
       </div>
     </div>

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import _ from "lodash";
   import { getRandomColor } from "../utils";
+  import Switch from "./Switch.svelte";
 
   export let percent: number;
   export let playing: boolean;
@@ -11,6 +12,7 @@
   export let robotWidth: number;
   export let robotHeight: number;
   export let sampleCircleRadius: number | null;
+  export let allianceColor: "red" | "blue";
   export let robotXY: BasePoint;
   export let robotHeading: number;
   export let x: d3.ScaleLinear<number, number, number>;
@@ -44,6 +46,13 @@
           type="number"
           class="pl-1.5 rounded-md bg-neutral-100 border-[0.5px] focus:outline-none w-16 dark:bg-neutral-950 dark:border-neutral-700"
           step="0.5"
+        />
+        <div class="font-extralight">Alliance Color:</div>
+        <Switch
+          bind:value={allianceColor}
+          options={["blue", "red"]}
+          label=""
+          fontSize={14}
         />
       </div>
     </div>

--- a/src/lib/Switch.svelte
+++ b/src/lib/Switch.svelte
@@ -1,0 +1,266 @@
+<script>
+    // based on suggestions from:
+    // Inclusive Components by Heydon Pickering https://inclusive-components.design/toggle-button/
+    // On Designing and Building Toggle Switches by Sara Soueidan https://www.sarasoueidan.com/blog/toggle-switch-design/
+    // and this example by Scott O'hara https://codepen.io/scottohara/pen/zLZwNv
+
+
+    export let label;
+    export let design = 'inner label'
+    export let options = [];
+    export let fontSize = 16;
+    export let value = 'on';
+
+    let checked = true;
+
+
+    const uniqueID = Math.floor(Math.random() * 100)
+
+    function handleClick(event){
+        const target = event.target
+
+        const state = target.getAttribute('aria-checked')
+
+        checked = state !== 'true'
+
+        value = checked === true ? 'on' : 'off'
+    }
+
+    const slugify = (str = "") =>
+        str.toLowerCase().replace(/ /g, "-").replace(/\./g, "");
+
+</script>
+
+{#if design == 'inner'}
+    <div class="s s--inner">
+        <span id={`switch-${uniqueID}`}>{label}</span>
+        <button
+                role="switch"
+                aria-checked={checked}
+                aria-labelledby={`switch-${uniqueID}`}
+                on:click={handleClick}>
+            <span>on</span>
+            <span>off</span>
+        </button>
+    </div>
+{:else if design == 'slider'}
+    <div class="s s--slider" style="font-size:{fontSize}px">
+        <span id={`switch-${uniqueID}`}>{label}</span>
+        <button
+                role="switch"
+                aria-checked={checked}
+                aria-labelledby={`switch-${uniqueID}`}
+                on:click={handleClick}>
+        </button>
+    </div>
+{:else}
+    <div class="s s--multi">
+        <div role='radiogroup'
+             class="group-container"
+             aria-labelledby={`label-${uniqueID}`}
+             style="font-size:{fontSize}px"
+             id={`group-${uniqueID}`}>
+            <div class='legend' id={`label-${uniqueID}`}>{label}</div>
+            {#each options as option}
+                <input type="radio" id={`${option}-${uniqueID}`} value={option} bind:group={value}>
+                <label for={`${option}-${uniqueID}`}>
+                    {option}
+                </label>
+            {/each}
+        </div>
+    </div>
+
+{/if}
+
+<style>
+    :root {
+        --accent-color: Red;
+        --blue-color: CornflowerBlue;
+    }
+    /* Inner Design Option */
+    .s--inner button {
+        padding: 0.5em;
+        background-color: #fff;
+        border: 1px solid var(--blue-color);
+    }
+    [role='switch'][aria-checked='true'] :first-child,
+    [role='switch'][aria-checked='false'] :last-child {
+        display: none;
+        color: #fff;
+    }
+
+    .s--inner button span {
+        user-select: none;
+        pointer-events:none;
+        padding: 0.25em;
+    }
+
+    .s--inner button:focus {
+        outline: var(--accent-color) solid 1px;
+    }
+
+    /* Slider Design Option */
+
+    .s--slider {
+        display: flex;
+        align-items: center;
+    }
+
+    .s--slider button {
+        width: 3em;
+        height: 1.6em;
+        position: relative;
+        margin: 0 0 0 0.5em;
+        background: var(--blue-color);
+        border: none;
+    }
+
+    .s--slider button::before {
+        content: '';
+        position: absolute;
+        width: 1.3em;
+        height: 1.3em;
+        background: #fff;
+        top: 0.13em;
+        right: 1.5em;
+        transition: transform 0.3s;
+    }
+
+    .s--slider button[aria-checked='true']{
+        background-color: var(--accent-color)
+    }
+
+    .s--slider button[aria-checked='true']::before{
+        transform: translateX(1.3em);
+        transition: transform 0.3s;
+    }
+
+    .s--slider button:focus {
+        box-shadow: 0 0px 0px 1px var(--accent-color);
+    }
+
+    /* Multi Design Option */
+
+    /* Based on suggestions from Sara Soueidan https://www.sarasoueidan.com/blog/toggle-switch-design/
+    and this example from Scott O'hara https://codepen.io/scottohara/pen/zLZwNv */
+
+    .s--multi .group-container {
+        border: none;
+        padding: 0;
+        white-space: nowrap;
+    }
+
+    /* .s--multi legend {
+    font-size: 2px;
+    opacity: 0;
+    position: absolute;
+    } */
+
+    .s--multi label {
+        display: inline-block;
+        line-height: 1.6;
+        position: relative;
+        z-index: 2;
+    }
+
+    .s--multi input {
+        opacity: 0;
+        position: absolute;
+    }
+
+    .s--multi label:first-of-type {
+        padding-right: 5em;
+    }
+
+    .s--multi label:last-child {
+        margin-left: -5em;
+        padding-left: 5em;
+    }
+
+    .s--multi:focus-within label:first-of-type:after {
+        box-shadow: 0 0px 8px var(--accent-color);
+        border-radius: 1.5em;
+    }
+
+
+
+    /* making the switch UI.  */
+    .s--multi label:first-of-type:before,
+    .s--multi label:first-of-type:after {
+        content: "";
+        height: 1.25em;
+        overflow: hidden;
+        pointer-events: none;
+        position: absolute;
+        vertical-align: middle;
+    }
+
+    .s--multi label:first-of-type:before {
+        border-radius: 100%;
+        z-index: 2;
+        position: absolute;
+        width: 1.2em;
+        height: 1.2em;
+        background: #fff;
+        top: 0.2em;
+        right: 1.2em;
+        transition: transform 0.3s;
+    }
+
+    .s--multi label:first-of-type:after {
+        background: var(--accent-color);
+        border-radius: 1em;
+        margin: 0 1em;
+        transition: background .2s ease-in-out;
+        width: 3em;
+        height: 1.6em;
+    }
+
+    .s--multi input:first-of-type:checked ~ label:first-of-type:after {
+        background: var(--blue-color);
+    }
+
+    .s--multi input:first-of-type:checked ~ label:first-of-type:before {
+        transform: translateX(-1.4em);
+    }
+
+    .s--multi input:last-of-type:checked ~ label:last-of-type {
+        z-index: 1;
+    }
+
+    .s--multi input:focus {
+        box-shadow: 0 0px 8px var(--accent-color);
+        border-radius: 1.5em;
+    }
+
+    /* gravy */
+
+    /* Inner Design Option */
+    [role='switch'][aria-checked='true'] :first-child,
+    [role='switch'][aria-checked='false'] :last-child {
+        border-radius: 0.25em;
+        background: var(--accent-color);
+        display: inline-block;
+    }
+
+    .s--inner button:focus {
+        box-shadow: 0 0px 8px var(--accent-color);
+        border-radius: 0.1em;
+    }
+
+    /* Slider Design Option */
+    .s--slider button {
+        border-radius: 1.5em;
+    }
+
+    .s--slider button::before {
+        border-radius: 100%;
+    }
+
+    .s--slider button:focus {
+        box-shadow: 0 0px 8px var(--accent-color);
+        border-radius: 1.5em;
+    }
+
+
+</style>


### PR DESCRIPTION
Adds circles with custom size around samples for easier auto creation on robots that extend when intaking samples in auto. Still needs some work to simplify the Switch component and the UI.

Also if the browser window is not full screen this breaks, but so do all of the trajectories