### PR TITLE
Fix protractor angles

### DIFF
--- a/src/lib/MathTools.svelte
+++ b/src/lib/MathTools.svelte
@@ -289,7 +289,7 @@
 
       <!-- Angle display -->
       <text x="0" y={-protractorRadius - 15} class="fill-red-600 dark:fill-red-400 text-sm font-bold" text-anchor="middle">
-        {normalizedProtractorAngle}°
+        {360 - normalizedProtractorAngle}°
       </text>
 
       <!-- Resize Handle -->


### PR DESCRIPTION
PR implementing the [suggestion](https://discord.com/channels/1262595185699717140/1441610548067303595) from discord. 

Protractor was showing angles mirrored across X axis, fixed by subtracting calculated angle from 360.
