### PR TITLE
Add facing point heading interpolation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -257,6 +257,20 @@
         }
 
         break;
+      case "facing_point":
+        const facingPoint = {
+          x: x(currentLine.endPoint.facingPointX ?? currentLine.endPoint.x),
+          y: y(currentLine.endPoint.facingPointY ?? currentLine.endPoint.y)
+        };
+
+        const fdx = facingPoint.x - robotXY.x;
+        const fdy = facingPoint.y - robotXY.y;
+
+        if (fdx !== 0 || fdy !== 0) {
+          robotHeading = radiansToDegrees(Math.atan2(fdy, fdx));
+        }
+
+        break;
     }
   }
 

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -190,11 +190,13 @@
               title="The heading style of the robot. 
 With constant heading, the robot maintains the same heading throughout the line. 
 With linear heading, heading changes linearly between given start and end angles. 
-With tangential heading, the heading follows the direction of the line."
+With tangential heading, the heading follows the direction of the line.
+With facing point heading, the robot points to a specified coordinate."
             >
               <option value="constant">Constant</option>
               <option value="linear">Linear</option>
               <option value="tangential">Tangential</option>
+              <option value="facing_point">Facing Point</option>
             </select>
 
             {#if line.endPoint.heading === "linear"}
@@ -229,6 +231,27 @@ With tangential heading, the heading follows the direction of the line."
             {:else if line.endPoint.heading === "tangential"}
               <p class="text-sm font-extralight">Reverse:</p>
               <input type="checkbox" bind:checked={line.endPoint.reverse} title="Reverse the direction the robot faces along the tangential path" />
+            {:else if line.endPoint.heading === "facing_point"}
+              <div class="flex flex-row items-center gap-2">
+                <input
+                  class="pl-1.5 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none w-20"
+                  step="0.1"
+                  type="number"
+                  min="0"
+                  max="144"
+                  bind:value={line.endPoint.facingPointX}
+                  title="The X coordinate (in inches) the robot should face while following this line"
+                />
+                <input
+                  class="pl-1.5 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none w-20"
+                  step="0.1"
+                  type="number"
+                  min="0"
+                  max="144"
+                  bind:value={line.endPoint.facingPointY}
+                  title="The Y coordinate (in inches) the robot should face while following this line"
+                />
+              </div>
             {/if}
             <button
               class="px-2 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none text-sm"

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -67,6 +67,7 @@
       constant: "setConstantHeadingInterpolation",
       linear: "setLinearHeadingInterpolation",
       tangential: "setTangentHeadingInterpolation",
+      facing_point: "setHeadingInterpolation",
     };
 
     let pathsClass = `
@@ -99,7 +100,18 @@
                               }
             new Pose(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)})
           )
-        ).${headingTypeToFunctionName[line.endPoint.heading]}(${line.endPoint.heading === "constant" ? `Math.toRadians(${line.endPoint.degrees})` : line.endPoint.heading === "linear" ? `Math.toRadians(${line.endPoint.startDeg}), Math.toRadians(${line.endPoint.endDeg})` : ""})
+        ).${headingTypeToFunctionName[line.endPoint.heading]}(${(() => {
+          if (line.endPoint.heading === "constant") {
+            return `Math.toRadians(${line.endPoint.degrees})`;
+          } else if (line.endPoint.heading === "linear") {
+            return `Math.toRadians(${line.endPoint.startDeg}), Math.toRadians(${line.endPoint.endDeg})`;
+          } else if (line.endPoint.heading === "facing_point") {
+            const faceX = line.endPoint.facingPointX ?? line.endPoint.x;
+            const faceY = line.endPoint.facingPointY ?? line.endPoint.y;
+            return `HeadingInterpolator.facingPoint(${faceX.toFixed(3)}, ${faceY.toFixed(3)})`;
+          }
+          return "";
+        })()})
         ${line.endPoint.reverse ? ".setReversed(true)" : ""}
         .build();`
                               }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,8 @@ type Point = BasePoint &
         endDeg: number;
         degrees?: never;
         reverse?: never;
+        facingPointX: never;
+        facingPointY: never;
       }
     | {
         heading: "constant";
@@ -18,6 +20,8 @@ type Point = BasePoint &
         startDeg?: never;
         endDeg?: never;
         reverse?: never;
+        facingPointX: never;
+        facingPointY: never;
       }
     | {
         heading: "tangential";
@@ -25,6 +29,17 @@ type Point = BasePoint &
         startDeg?: never;
         endDeg?: never;
         reverse: boolean;
+        facingPointX: never;
+        facingPointY: never;
+      }
+    | {
+        heading: "facing_point";
+        startDeg?: never;
+        endDeg?: never;
+        degrees?: never;
+        reverse?: never;
+        facingPointX: number;
+        facingPointY: number;
       }
   );
 
@@ -41,7 +56,7 @@ interface FPALine {
   startPoint: Point;
   endPoint: Point;
   controlPoints: ControlPoint[];
-  interpolation: String;
+  interpolation: Point["heading"];
   color: string;
   name?: string;
 }


### PR DESCRIPTION
Adds [Facing Point Interpolation](https://pedropathing.com/docs/pathing/reference/interpolation#facing-point-interpolation) to the visualizer.

The code generator outputs `setHeadingInterpolation(HeadingInterpolator.facingPoint(faceX, faceY))`

<img width="1837" height="922" alt="image" src="https://github.com/user-attachments/assets/17666319-2e9a-456c-adfb-2bac3d377891" />

I didn't change the `fpa` function in App.svelte as the FPA optimization endpoint doesn't know about facing point.