### PR TITLE
Add support for path chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001746",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001746.tgz",
-      "integrity": "sha512-eA7Ys/DGw+pnkWWSE/id29f2IcPHVoE8wxtvE5JdvD2V28VTDPy1yEeo11Guz0sJ4ZeGRcm3uaTcAqK1LXaphA==",
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
       "dev": true,
       "funding": [
         {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
     Settings,
     Point,
     SequenceItem,
+    PathChain,
     Shape,
   } from "./types";
   import * as d3 from "d3";
@@ -147,6 +148,16 @@
     kind: "path",
     lineId: ln.id!,
   }));
+  const makeChainId = () =>
+    `chain-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const defaultPathChainName = "Main Chain";
+  const createDefaultPathChain = (sourceLines: Line[]): PathChain => ({
+    id: makeChainId(),
+    name: defaultPathChainName,
+    color: getRandomColor(),
+    lineIds: sourceLines.map((ln) => ln.id!).filter(Boolean),
+  });
+  let pathChains: PathChain[] = [createDefaultPathChain(lines)];
   let shapes: Shape[] = getDefaultShapes();
   let optimizingLineIds: Record<string, boolean> = {};
   let optimizingAll = false;
@@ -180,6 +191,7 @@
       shapes,
       sequence,
       settings,
+      pathChains,
     };
   }
 
@@ -199,6 +211,7 @@
       shapes = prev.shapes;
       sequence = prev.sequence;
       settings = prev.settings;
+      pathChains = prev.pathChains;
       isUnsaved.set(true);
       two && two.update();
     }
@@ -214,8 +227,39 @@
       shapes = next.shapes;
       sequence = next.sequence;
       settings = next.settings;
+      pathChains = next.pathChains;
       isUnsaved.set(true);
       two && two.update();
+    }
+  }
+
+  function normalizePathChains(
+    sourceChains: PathChain[] | undefined,
+    sourceLines: Line[],
+  ): PathChain[] {
+    const validLineIds = new Set(sourceLines.map((ln) => ln.id!).filter(Boolean));
+    const cleaned = (sourceChains || [])
+      .map((chain) => ({
+        ...chain,
+        id: chain.id || makeChainId(),
+        name: (chain.name || "").trim() || defaultPathChainName,
+        color: chain.color || getRandomColor(),
+        lineIds: (chain.lineIds || []).filter((id) => validLineIds.has(id)),
+      }));
+
+    if (cleaned.length === 0) {
+      return [createDefaultPathChain(sourceLines)];
+    }
+
+    return cleaned;
+  }
+
+  $: {
+    const normalized = normalizePathChains(pathChains, lines);
+    const current = JSON.stringify(pathChains);
+    const next = JSON.stringify(normalized);
+    if (current !== next) {
+      pathChains = normalized;
     }
   }
 
@@ -1910,6 +1954,7 @@
         lines,
         shapes,
         sequence,
+        pathChains,
         settings,
         version: "1.2.1",
         timestamp: new Date().toISOString(),
@@ -2001,7 +2046,7 @@
       console.error("Failed to save into app storage:", err);
       // As a last resort, download the file
       try {
-        downloadTrajectory(startPoint, lines, shapes, sequence);
+        downloadTrajectory(startPoint, lines, shapes, sequence, pathChains);
       } catch (err2) {
         console.error("Save As fallback failed:", err2);
         alert(
@@ -2390,6 +2435,7 @@
           lines,
           shapes,
           sequence,
+          pathChains,
           settings,
           version: "1.2.1",
           timestamp: new Date().toISOString(),
@@ -2454,6 +2500,7 @@
               lineId: ln.id!,
             }))
       ) as SequenceItem[];
+      pathChains = normalizePathChains(data.pathChains, normalizedLines);
 
       // Load shapes with defaults
       shapes = data.shapes || [];
@@ -2507,6 +2554,7 @@
             lineId: ln.id!,
           }))
     ) as SequenceItem[];
+    pathChains = normalizePathChains(data.pathChains, normalizedLines);
 
     // Load shapes with defaults
     shapes = data.shapes || [];
@@ -2833,6 +2881,7 @@
           lines,
           shapes,
           sequence,
+          pathChains,
           settings,
         });
         
@@ -2863,6 +2912,7 @@
             lines,
             shapes,
             sequence,
+            pathChains,
             settings,
             version: "1.2.1",
             timestamp: new Date().toISOString(),
@@ -2888,6 +2938,7 @@
               lines,
               shapes,
               sequence,
+              pathChains,
               settings,
               version: "1.2.1",
               timestamp: new Date().toISOString(),
@@ -2939,6 +2990,7 @@
   bind:startPoint
   bind:shapes
   bind:sequence
+  bind:pathChains
   bind:secondStartPoint
   bind:secondLines
   bind:secondShapes
@@ -3201,6 +3253,7 @@ pointer-events: none; opacity: ${1.0 - idx * 0.15};`}
     bind:startPoint
     bind:lines
     bind:sequence
+    bind:pathChains
     bind:robotWidth
     bind:robotHeight
     bind:settings

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,7 +12,7 @@ export const DEFAULT_ROBOT_HEIGHT = 16;
  */
 export const POINT_RADIUS = 1.15;
 export const LINE_WIDTH = 0.57;
-export const FIELD_SIZE = 144;
+export const FIELD_SIZE = 141.5;
 
 /**
  * Available field maps
@@ -96,9 +96,9 @@ export function getDefaultShapes(): Shape[] {
       id: "triangle-1",
       name: "Red Goal",
       vertices: [
-        { x: 144, y: 70 },
-        { x: 144, y: 144 },
-        { x: 120, y: 144 },
+        { x: 141.5, y: 70 },
+        { x: 141.5, y: 141.5 },
+        { x: 120, y: 141.5 },
         { x: 138, y: 119 },
         { x: 138, y: 70 },
       ],
@@ -110,10 +110,10 @@ export function getDefaultShapes(): Shape[] {
       name: "Blue Goal",
       vertices: [
         { x: 6, y: 119 },
-        { x: 25, y: 144 },
-        { x: 0, y: 144 },
+        { x: 25, y: 141.5 },
+        { x: 0, y: 141.5 },
         { x: 0, y: 70 },
-        { x: 7, y: 70 },
+        { x: 6, y: 70 },
       ],
       color: "#2563eb",
       fillColor: "#60a5fa",

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -6,6 +6,7 @@
     Settings,
     Shape,
     SequenceItem,
+    PathChain,
   } from "../types";
   import _ from "lodash";
   import { getRandomColor } from "../utils";
@@ -24,6 +25,7 @@
   export let startPoint: Point;
   export let lines: Line[];
   export let sequence: SequenceItem[];
+  export let pathChains: PathChain[] = [];
   export let robotWidth: number = 16;
   export let robotHeight: number = 16;
   export let robotXY: BasePoint;
@@ -38,6 +40,257 @@
 
   export let shapes: Shape[];
   export let recordChange: () => void;
+
+  const makeChainId = () =>
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const defaultChainName = "Main Chain";
+
+  let selectedChainId = "";
+  let chainNameDraft = "";
+  let chainColorDraft = "#22c55e";
+  let selectedChain: PathChain | null = null;
+  let previousSelectedChainId = "";
+  let chainOptions: Array<{ id: string; name: string; color: string }> = [];
+
+  const getChainById = (chainId: string): PathChain | null =>
+    pathChains.find((chain) => chain.id === chainId) || null;
+
+  function getLinePrimaryChainId(lineId: string): string {
+    for (const chain of pathChains) {
+      if ((chain.lineIds || []).includes(lineId)) return chain.id;
+    }
+    return pathChains[0]?.id || "";
+  }
+
+  function syncLineColorsToChains() {
+    const chainColorById = new Map(pathChains.map((chain) => [chain.id, chain.color || "#22c55e"]));
+    let changed = false;
+    const nextLines = lines.map((line) => {
+      const ownerId = getLinePrimaryChainId(line.id || "");
+      const targetColor = chainColorById.get(ownerId) || line.color;
+      if (line.color !== targetColor) {
+        changed = true;
+        return { ...line, color: targetColor };
+      }
+      return line;
+    });
+    if (changed) {
+      lines = nextLines;
+    }
+  }
+
+  function ensureDefaultChain() {
+    if (pathChains.length === 0) {
+      pathChains = [
+        {
+          id: makeChainId(),
+          name: defaultChainName,
+          color: getRandomColor(),
+          lineIds: lines.map((ln) => ln.id!).filter(Boolean),
+        },
+      ];
+      selectedChainId = pathChains[0]?.id || "";
+      return;
+    }
+
+    if (!selectedChainId || !pathChains.some((c) => c.id === selectedChainId)) {
+      selectedChainId = pathChains[0]?.id || "";
+    }
+  }
+
+  $: {
+    const normalized = pathChains.map((chain) => ({
+      ...chain,
+      color: chain.color || getRandomColor(),
+      lineIds: chain.lineIds || [],
+    }));
+    if (JSON.stringify(normalized) !== JSON.stringify(pathChains)) {
+      pathChains = normalized;
+    }
+  }
+
+  $: ensureDefaultChain();
+
+  $: selectedChain =
+    pathChains.find((chain) => chain.id === selectedChainId) || pathChains[0] || null;
+
+  $: if (selectedChainId !== previousSelectedChainId) {
+    chainNameDraft = selectedChain?.name || "";
+    chainColorDraft = selectedChain?.color || "#22c55e";
+    previousSelectedChainId = selectedChainId;
+  }
+
+  function ensureLineInDefaultChain(lineId: string) {
+    if (!lineId || !pathChains.length) return;
+    assignLineToChain(lineId, pathChains[0].id);
+  }
+
+  function removeLineFromChains(lineId: string) {
+    if (!lineId) return;
+    const updated = pathChains.map((chain) => ({
+        ...chain,
+        lineIds: chain.lineIds.filter((id) => id !== lineId),
+      }));
+    pathChains = updated;
+    ensureDefaultChain();
+    syncLineColorsToChains();
+  }
+
+  function assignLineToChain(lineId: string, chainId: string) {
+    if (!lineId || !chainId) return;
+    pathChains = pathChains.map((chain) => ({
+      ...chain,
+      lineIds: chain.lineIds.filter((id) => id !== lineId),
+    }));
+
+    const target = getChainById(chainId);
+    if (!target) return;
+
+    pathChains = pathChains.map((chain) => {
+      if (chain.id !== chainId) return chain;
+      return {
+        ...chain,
+        lineIds: Array.from(new Set([...(chain.lineIds || []), lineId])),
+      };
+    });
+
+    syncLineColorsToChains();
+    recordChange?.();
+  }
+
+  function addPathChain() {
+    const newChain: PathChain = {
+      id: makeChainId(),
+      name: `Chain ${pathChains.length + 1}`,
+      color: getRandomColor(),
+      lineIds: [],
+    };
+    pathChains = [...pathChains, newChain];
+    selectedChainId = newChain.id;
+    recordChange?.();
+  }
+
+  function duplicateSelectedPathChain() {
+    if (!selectedChain) return;
+
+    const sourceLineIds = selectedChain.lineIds || [];
+    const selectedLineSet = new Set(sourceLineIds);
+    const lineLookup = new Map(lines.map((line) => [line.id, line]));
+    const idMap = new Map<string, string>();
+    const clonedLines: Line[] = [];
+
+    // Keep duplication order aligned with timeline, then append any non-sequenced lines.
+    const orderedSourceIds: string[] = [];
+    sequence.forEach((item) => {
+      if (item.kind === "path" && selectedLineSet.has(item.lineId)) {
+        orderedSourceIds.push(item.lineId);
+      }
+    });
+    sourceLineIds.forEach((lineId) => {
+      if (!orderedSourceIds.includes(lineId)) {
+        orderedSourceIds.push(lineId);
+      }
+    });
+
+    orderedSourceIds.forEach((sourceId, index) => {
+      const sourceLine = lineLookup.get(sourceId);
+      if (!sourceLine) return;
+      const clone = JSON.parse(JSON.stringify(sourceLine)) as Line;
+      const newLineId = makeId();
+      clone.id = newLineId;
+      clone.name = `${sourceLine.name || `Path ${lines.length + index + 1}`} Copy`;
+      idMap.set(sourceId, newLineId);
+      clonedLines.push(clone);
+    });
+
+    const newSequence: SequenceItem[] = [];
+    sequence.forEach((item) => {
+      newSequence.push(item);
+      if (item.kind === "path") {
+        const clonedId = idMap.get(item.lineId);
+        if (clonedId) {
+          newSequence.push({ kind: "path", lineId: clonedId });
+        }
+      }
+    });
+
+    // If chain contains lines currently not present in the timeline, append their clones.
+    orderedSourceIds.forEach((sourceId) => {
+      const inSequence = sequence.some((item) => item.kind === "path" && item.lineId === sourceId);
+      const clonedId = idMap.get(sourceId);
+      if (!inSequence && clonedId) {
+        newSequence.push({ kind: "path", lineId: clonedId });
+      }
+    });
+
+    lines = [...lines, ...clonedLines];
+    sequence = newSequence;
+    syncLinesToSequence(newSequence);
+
+    const duplicateChain: PathChain = {
+      id: makeChainId(),
+      name: `${selectedChain.name} Copy`,
+      color: getRandomColor(),
+      lineIds: orderedSourceIds.map((sourceId) => idMap.get(sourceId)).filter(Boolean) as string[],
+    };
+
+    const selectedIndex = pathChains.findIndex((chain) => chain.id === selectedChain.id);
+    if (selectedIndex >= 0) {
+      pathChains = [
+        ...pathChains.slice(0, selectedIndex + 1),
+        duplicateChain,
+        ...pathChains.slice(selectedIndex + 1),
+      ];
+    } else {
+      pathChains = [...pathChains, duplicateChain];
+    }
+
+    selectedChainId = duplicateChain.id;
+    syncLineColorsToChains();
+    recordChange?.();
+  }
+
+  function removeSelectedPathChain() {
+    if (!selectedChain || pathChains.length <= 1) return;
+    const fallbackChainId = pathChains.find((chain) => chain.id !== selectedChain.id)?.id;
+    const orphanedLines = [...(selectedChain.lineIds || [])];
+    pathChains = pathChains.filter((chain) => chain.id !== selectedChain.id);
+
+    if (fallbackChainId) {
+      orphanedLines.forEach((lineId) => assignLineToChain(lineId, fallbackChainId));
+    }
+
+    selectedChainId = pathChains[0]?.id || "";
+    syncLineColorsToChains();
+    recordChange?.();
+  }
+
+  function updateSelectedChainName() {
+    if (!selectedChain) return;
+    const nextName = chainNameDraft.trim();
+    if (!nextName) return;
+    pathChains = pathChains.map((chain) =>
+      chain.id === selectedChain.id ? { ...chain, name: nextName } : chain,
+    );
+    recordChange?.();
+  }
+
+  function updateSelectedChainColor() {
+    if (!selectedChain) return;
+    pathChains = pathChains.map((chain) =>
+      chain.id === selectedChain.id ? { ...chain, color: chainColorDraft } : chain,
+    );
+    syncLineColorsToChains();
+    recordChange?.();
+  }
+
+  $: chainOptions = pathChains.map((chain) => ({
+    id: chain.id,
+    name: chain.name,
+    color: chain.color || "#22c55e",
+  }));
+
+  $: syncLineColorsToChains();
 
   // Reference exported but unused props to silence Svelte unused-export warnings
 
@@ -158,8 +411,8 @@
         };
       } else {
         newPoint = {
-          x: _.random(0, 144),
-          y: _.random(0, 144),
+          x: _.random(0, 141.5),
+          y: _.random(0, 141.5),
           heading: "tangential",
           reverse: false,
         };
@@ -186,6 +439,7 @@
     const newSeq = [...sequence];
     newSeq.splice(seqIndex + 1, 0, { kind: "path", lineId: newLine.id! });
     sequence = newSeq;
+    ensureLineInDefaultChain(newLine.id!);
 
     collapsedSections.lines.splice(lineIndex + 1, 0, false);
     collapsedSections.controlPoints.splice(lineIndex + 1, 0, true);
@@ -250,6 +504,7 @@
     const newSeq = [...sequence];
     newSeq.splice(seqIndex + 1, 0, { kind: "path", lineId: newLine.id! });
     sequence = newSeq;
+    ensureLineInDefaultChain(newLine.id!);
 
     collapsedSections.lines.splice(lineIndex + 1, 0, false);
     collapsedSections.controlPoints.splice(lineIndex + 1, 0, true);
@@ -267,6 +522,7 @@
       sequence = sequence.filter(
         (s) => s.kind === "wait" || s.lineId !== removedId,
       );
+      removeLineFromChains(removedId);
     }
     collapsedSections.lines.splice(idx, 1);
     collapsedSections.controlPoints.splice(idx, 1);
@@ -278,8 +534,8 @@
       id: makeId(),
       name: `Path ${lines.length + 1}`,
       endPoint: {
-        x: _.random(0, 144),
-        y: _.random(0, 144),
+        x: _.random(0, 141.5),
+        y: _.random(0, 141.5),
         heading: "tangential",
         reverse: false,
       },
@@ -292,6 +548,7 @@
     };
     lines = [...lines, newLine];
     sequence = [...sequence, { kind: "path", lineId: newLine.id! }];
+    ensureLineInDefaultChain(newLine.id!);
     collapsedSections.lines.push(false);
     collapsedSections.controlPoints.push(true);
     recordChange();
@@ -378,8 +635,8 @@
       id: makeId(),
       name: `Path ${lines.length + 1}`,
       endPoint: {
-        x: _.random(0, 144),
-        y: _.random(0, 144),
+        x: _.random(0, 141.5),
+        y: _.random(0, 141.5),
         heading: "tangential",
         reverse: false,
       },
@@ -392,6 +649,7 @@
     };
     lines = [newLine, ...lines];
     sequence = [{ kind: "path", lineId: newLine.id! }, ...sequence];
+    ensureLineInDefaultChain(newLine.id!);
     collapsedSections.lines = [false, ...collapsedSections.lines];
     collapsedSections.controlPoints = [
       true,
@@ -438,6 +696,7 @@
     const newSeq = [...sequence];
     newSeq.splice(seqIndex + 1, 0, { kind: "path", lineId: newLine.id! });
     sequence = newSeq;
+    ensureLineInDefaultChain(newLine.id!);
 
     // Add UI state for the new line
     collapsedSections.lines.push(false);
@@ -524,6 +783,54 @@
 
     <StartingPointSection bind:startPoint {addPathAtStart} {addWaitAtStart} />
 
+    <div class="w-full rounded-md border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-800">
+      <div class="flex items-center gap-2 mb-2">
+        <p class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-300">Path Chains</p>
+        <select
+          bind:value={selectedChainId}
+          class="flex-1 px-2 py-1 text-xs rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-900"
+        >
+          {#each pathChains as chain (chain.id)}
+            <option value={chain.id}>{chain.name} ({(chain.lineIds || []).length})</option>
+          {/each}
+        </select>
+        <button on:click={addPathChain} class="px-2 py-1 text-xs rounded bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-200">New</button>
+        <button on:click={duplicateSelectedPathChain} class="px-2 py-1 text-xs rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200">Duplicate</button>
+        <button
+          on:click={removeSelectedPathChain}
+          disabled={pathChains.length <= 1}
+          class="px-2 py-1 text-xs rounded bg-rose-100 text-rose-700 dark:bg-rose-900 dark:text-rose-200 disabled:opacity-40"
+        >
+          Remove
+        </button>
+      </div>
+
+      {#if selectedChain}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-2">
+          <div class="flex items-center gap-2">
+            <input
+              type="text"
+              bind:value={chainNameDraft}
+              on:input={updateSelectedChainName}
+              class="flex-1 px-2 py-1 text-xs rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-900"
+              placeholder="Chain name"
+            />
+          </div>
+
+          <div class="flex items-center gap-2">
+            <input
+              type="color"
+              bind:value={chainColorDraft}
+              on:input={updateSelectedChainColor}
+              class="w-10 h-8 rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-900"
+              title="Path chain color"
+            />
+            <span class="text-xs text-neutral-500 dark:text-neutral-400">Path color</span>
+          </div>
+        </div>
+      {/if}
+    </div>
+
     <!-- Unified sequence render: paths and waits -->
     {#each sequence as item, sIdx}
       <div class="w-full">
@@ -552,6 +859,9 @@
               canMoveDown={sIdx !== sequence.length - 1}
               optimizeLine={optimizeLine}
               optimizing={optimizingLineIds?.[ln.id ?? ""] ?? false}
+              chainOptions={chainOptions}
+              selectedChainId={getLinePrimaryChainId(ln.id || "")}
+              onChainChange={(chainId) => assignLineToChain(ln.id || "", chainId)}
               {recordChange}
             />
           {/each}

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -7,7 +7,7 @@
 
   import { cubicInOut } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
-  import type { FileInfo, Point, Line, Shape, SequenceItem } from "../types";
+  import type { FileInfo, Point, Line, Shape, SequenceItem, PathChain } from "../types";
   import * as browserFileStore from "../utils/browserFileStore";
   import { currentFilePath, isUnsaved, dualPathMode, secondFilePath } from "../stores";
   import { getRandomColor } from "../utils";
@@ -22,6 +22,7 @@
   export let lines: Line[];
   export let shapes: Shape[];
   export let sequence: SequenceItem[];
+  export let pathChains: PathChain[] = [];
   export let secondStartPoint: Point | null = null;
   export let secondLines: Line[] = [];
   export let secondShapes: Shape[] = [];
@@ -248,6 +249,7 @@
       lines = normalizedLines;
       shapes = data.shapes || [];
       sequence = deriveSequence(data, normalizedLines);
+      pathChains = data.pathChains || [];
 
       // Update Global Store State
       currentFilePath.set(file.path);
@@ -318,6 +320,7 @@
         lines,
         shapes,
         sequence,
+        pathChains,
         version: "1.2.1", // Add version for compatibility
         timestamp: new Date().toISOString(),
       });
@@ -341,6 +344,7 @@
         lines,
         shapes,
         sequence,
+        pathChains,
         version: "1.2.1",
         timestamp: new Date().toISOString(),
       }, null, 2);
@@ -393,6 +397,7 @@
         lines,
         shapes,
         sequence,
+        pathChains,
         version: "1.2.1",
         timestamp: new Date().toISOString(),
       }, null, 2);
@@ -441,6 +446,7 @@
         lines: normalizedLines,
         shapes,
         sequence,
+        pathChains,
         version: "1.2.1",
         timestamp: new Date().toISOString(),
       });
@@ -704,7 +710,7 @@
 
     // Mirror start point
     if (mirrored.startPoint) {
-      mirrored.startPoint.x = 144 - mirrored.startPoint.x;
+      mirrored.startPoint.x = 141.5 - mirrored.startPoint.x;
       mirrored.startPoint = mirrorPointHeading(mirrored.startPoint);
     }
 
@@ -713,14 +719,14 @@
       mirrored.lines.forEach((line: Line) => {
         // Mirror end point
         if (line.endPoint) {
-          line.endPoint.x = 144 - line.endPoint.x;
+          line.endPoint.x = 141.5 - line.endPoint.x;
           line.endPoint = mirrorPointHeading(line.endPoint);
         }
 
         // Mirror control points
         if (line.controlPoints && Array.isArray(line.controlPoints)) {
           line.controlPoints.forEach((controlPoint: any) => {
-            controlPoint.x = 144 - controlPoint.x;
+            controlPoint.x = 141.5 - controlPoint.x;
           });
         }
       });

--- a/src/lib/MathTools.svelte
+++ b/src/lib/MathTools.svelte
@@ -120,7 +120,7 @@
     ? { x: x.invert(robotXY.x), y: y.invert(robotXY.y) }
     : protractorPos;
 
-  const FIELD_SIZE = 144;
+  const FIELD_SIZE = 141.5;
   let spacing = 12;
   let gridPositions: number[] = [];
   let labelInterval = 1; // Show label every N grid lines

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Point, Line, Shape, Settings, SequenceItem } from "../types";
+  import type { Point, Line, Shape, Settings, SequenceItem, PathChain } from "../types";
   import { onMount, onDestroy } from "svelte";
   import {
     showRuler,
@@ -32,6 +32,7 @@
   export let lines: Line[];
   export let shapes: Shape[];
   export let sequence: SequenceItem[];
+  export let pathChains: PathChain[] = [];
   export let secondStartPoint: Point | null = null;
   export let secondLines: Line[] = [];
   export let secondShapes: Shape[] = [];
@@ -276,6 +277,7 @@
     bind:lines
     bind:shapes
     bind:sequence
+    bind:pathChains
     bind:secondStartPoint
     bind:secondLines
     bind:secondShapes
@@ -289,6 +291,7 @@
   bind:startPoint
   bind:lines
   bind:sequence
+  bind:pathChains
 />
 
 <SettingsDialog bind:isOpen={settingsOpen} bind:settings />

--- a/src/lib/components/ControlPointsSection.svelte
+++ b/src/lib/components/ControlPointsSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { Line } from "../../types";
-  import _ from "lodash";
   import { snapToGrid, showGrid, gridSize } from "../../stores";
 
   export let line: Line;
@@ -121,7 +120,7 @@
               bind:value={point.x}
               type="number"
               min="0"
-              max="144"
+              max="141.5"
               step={$snapToGrid && $showGrid ? $gridSize : 0.1}
               class="w-20 px-2 py-1 text-xs rounded-md bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
               on:change={() => {
@@ -138,7 +137,7 @@
               bind:value={point.y}
               type="number"
               min="0"
-              max="144"
+              max="141.5"
               step={$snapToGrid && $showGrid ? $gridSize : 0.1}
               class="w-20 px-2 py-1 text-xs rounded-md bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
               on:change={() => {

--- a/src/lib/components/ExportCodeDialog.svelte
+++ b/src/lib/components/ExportCodeDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Point, Line, SequenceItem } from "../../types";
+  import type { Point, Line, SequenceItem, PathChain } from "../../types";
   import Highlight from "svelte-highlight";
   import { java } from "svelte-highlight/languages";
   import plaintext from "svelte-highlight/languages/plaintext";
@@ -11,12 +11,13 @@
     generateJavaCode,
     generatePointsArray,
     generateSequentialCommandCode,
-  } from "../../utils";
+  } from "../../utils/codeExporter";
 
   export let isOpen = false;
   export let startPoint: Point;
   export let lines: Line[];
   export let sequence: SequenceItem[];
+  export let pathChains: PathChain[] = [];
 
   let exportMode: "full" | "class" | "coordinates" = "class";
   let exportFormat: "java" | "points" | "sequential" = "java";
@@ -52,6 +53,7 @@
           startPoint,
           lines,
           exportMode,
+          pathChains,
         );
         currentLanguage = java;
       } else if (format === "points") {
@@ -107,7 +109,7 @@
 
   async function handleExportModeChange() {
     if (exportFormat === "java") {
-      exportedCode = await generateJavaCode(startPoint, lines, exportMode);
+      exportedCode = await generateJavaCode(startPoint, lines, exportMode, pathChains);
     }
   }
 </script>

--- a/src/lib/components/ObstaclesSection.svelte
+++ b/src/lib/components/ObstaclesSection.svelte
@@ -169,7 +169,7 @@
               bind:value={vertex.x}
               type="number"
               min="0"
-              max="144"
+              max="141.5"
               step={$snapToGrid && $showGrid ? $gridSize : 0.1}
               title={snapToGridTitle}
               class="pl-1.5 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none w-24 text-sm"
@@ -179,7 +179,7 @@
               bind:value={vertex.y}
               type="number"
               min="0"
-              max="144"
+              max="141.5"
               step={$snapToGrid && $showGrid ? $gridSize : 0.1}
               class="pl-1.5 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none w-24 text-sm"
               title={snapToGridTitle}

--- a/src/lib/components/PathLineSection.svelte
+++ b/src/lib/components/PathLineSection.svelte
@@ -20,6 +20,9 @@
   export let canMoveDown: boolean = true;
   export let optimizeLine: (lineId: string, targetControlPointIndex?: number) => void;
   export let optimizing: boolean = false;
+  export let chainOptions: Array<{ id: string; name: string; color: string }> = [];
+  export let selectedChainId: string = "";
+  export let onChainChange: (chainId: string) => void;
 
 
   $: snapToGridTitle =
@@ -28,9 +31,16 @@
   function toggleCollapsed() {
     collapsed = !collapsed;
   }
+
+  function handleChainSelect(event: Event) {
+    const target = event.currentTarget as HTMLSelectElement;
+    if (onChainChange) {
+      onChainChange(target.value);
+    }
+  }
 </script>
 
-<div class="flex flex-col w-full justify-start items-start gap-1">
+<div class="flex flex-col w-full justify-start items-start gap-1 rounded-md p-1">
   <div class="flex flex-row w-full items-center gap-3 flex-wrap">
     <div class="flex flex-row items-center gap-2">
       <button
@@ -73,16 +83,23 @@
           if (recordChange) recordChange();
         }}
       />
+
+      <select
+        value={selectedChainId}
+        on:change={handleChainSelect}
+        class="px-2 py-1 text-xs rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-900"
+        title="Assign path chain"
+      >
+        {#each chainOptions as chain}
+          <option value={chain.id}>{chain.name}</option>
+        {/each}
+      </select>
+
       <div
         class="relative size-5 rounded-full overflow-hidden shadow-sm border border-neutral-300 dark:border-neutral-600 shrink-0"
         style="background-color: {line.color}"
       >
-        <input
-          type="color"
-          bind:value={line.color}
-          class="opacity-0 absolute inset-0 w-full h-full cursor-pointer"
-          title="Change Path Color"
-        />
+        <div class="absolute inset-0" title="Color comes from assigned path chain" />
       </div>
 
       <!-- Lock/Unlock Button -->
@@ -293,7 +310,7 @@
           step={$snapToGrid && $showGrid ? $gridSize : 0.1}
           type="number"
           min="0"
-          max="144"
+          max="141.5"
           bind:value={line.endPoint.x}
           disabled={line.locked}
           title={snapToGridTitle}
@@ -303,7 +320,7 @@
           class="pl-1.5 rounded-md bg-neutral-100 dark:bg-neutral-950 dark:border-neutral-700 border-[0.5px] focus:outline-none w-28"
           step={$snapToGrid && $showGrid ? $gridSize : 0.1}
           min="0"
-          max="144"
+          max="141.5"
           type="number"
           bind:value={line.endPoint.y}
           disabled={line.locked}

--- a/src/lib/components/StartingPointSection.svelte
+++ b/src/lib/components/StartingPointSection.svelte
@@ -57,7 +57,7 @@
     <input
       bind:value={startPoint.x}
       min="0"
-      max="144"
+      max="141.5"
       type="number"
       class="pl-1.5 rounded-md bg-neutral-100 border-[0.5px] focus:outline-none w-28 dark:bg-neutral-950 dark:border-neutral-700"
       step="0.1"
@@ -67,7 +67,7 @@
     <input
       bind:value={startPoint.y}
       min="0"
-      max="144"
+      max="141.5"
       type="number"
       class="pl-1.5 rounded-md bg-neutral-100 border-[0.5px] focus:outline-none w-28 dark:bg-neutral-950 dark:border-neutral-700"
       step="0.1"

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,13 @@ export type SequenceWaitItem = {
 
 export type SequenceItem = SequencePathItem | SequenceWaitItem;
 
+export interface PathChain {
+  id: string;
+  name: string;
+  color: string;
+  lineIds: string[];
+}
+
 export interface Settings {
   xVelocity: number;
   yVelocity: number;

--- a/src/utils/codeExporter.ts
+++ b/src/utils/codeExporter.ts
@@ -1,5 +1,5 @@
 import prettier from "prettier";
-import type { Point, Line, BasePoint } from "../types";
+import type { Point, Line, BasePoint, PathChain } from "../types";
 import { getCurvePoint } from "./math";
 
 // Lazy-load Prettier's Java plugin; fall back gracefully if unavailable
@@ -23,79 +23,106 @@ async function loadJavaPlugin() {
 /**
  * Generate Java code from path data
  */
-export async function generateJavaCode(
-  startPoint: Point,
-  lines: Line[],
-  exportMode: "full" | "class" | "coordinates" = "class",
-): Promise<string> {
+function sanitizeIdentifier(input: string | undefined, fallback: string): string {
+  const cleaned = (input || "").replace(/[^a-zA-Z0-9]/g, "");
+  if (!cleaned) return fallback;
+  if (/^[0-9]/.test(cleaned)) return `${fallback}${cleaned}`;
+  return cleaned;
+}
+
+function buildPathSegmentCode(line: Line, startExpression: string): string {
   const headingTypeToFunctionName = {
     constant: "setConstantHeadingInterpolation",
     linear: "setLinearHeadingInterpolation",
     tangential: "setTangentHeadingInterpolation",
   };
 
-  // Generate field declarations with proper indentation
-  const fieldDeclarations = lines
-    .map((line, idx) => {
-      const variableName = line.name
-        ? line.name.replace(/[^a-zA-Z0-9]/g, "")
-        : `line${idx + 1}`;
-      // declare waits as doubles, paths as PathChain
-      return (line as any).waitMs !== undefined
-        ? `public double ${variableName};`
-        : `public PathChain ${variableName};`;
-    })
-    .join("\n    ");
+  const controlPoints = line.controlPoints
+    .map((point) => `new Pose(${point.x.toFixed(3)}, ${point.y.toFixed(3)})`)
+    .join(",\n            ");
 
-  // Generate path assignments with proper indentation
-  const pathAssignments = lines
-    .map((line, idx) => {
-      const variableName = line.name
-        ? line.name.replace(/[^a-zA-Z0-9]/g, "")
-        : `line${idx + 1}`;
+  const curveType = line.controlPoints.length === 0 ? "BezierLine" : "BezierCurve";
 
-      if ((line as any).waitMs !== undefined) {
-        // assign wait duration (ms) to double
-        return `${variableName} = ${Number((line as any).waitMs)};`;
-      }
+  const allPoints = controlPoints
+    ? `${startExpression},\n            ${controlPoints},\n            new Pose(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)})`
+    : `${startExpression},\n            new Pose(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)})`;
 
-      const start =
-        idx === 0
-          ? `new Pose(${startPoint.x.toFixed(3)}, ${startPoint.y.toFixed(3)})`
-          : `new Pose(${lines[idx - 1].endPoint.x.toFixed(3)}, ${lines[idx - 1].endPoint.y.toFixed(3)})`;
-
-      const controlPoints = line.controlPoints
-        .map(
-          (point) =>
-            `new Pose(${point.x.toFixed(3)}, ${point.y.toFixed(3)})`,
-        )
-        .join(",\n            ");
-
-      const curveType =
-        line.controlPoints.length === 0 ? `BezierLine` : `BezierCurve`;
-
-      const allPoints = controlPoints
-        ? `${start},\n            ${controlPoints},\n            new Pose(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)})`
-        : `${start},\n            new Pose(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)})`;
-
-      const headingConfig =
-        line.endPoint.heading === "constant"
-          ? `Math.toRadians(${line.endPoint.degrees})`
-          : line.endPoint.heading === "linear"
-            ? `Math.toRadians(${line.endPoint.startDeg}), Math.toRadians(${line.endPoint.endDeg})`
-            : "";
-
-      const reverseConfig = line.endPoint.reverse
-        ? "\n          .setReversed()"
+  const headingConfig =
+    line.endPoint.heading === "constant"
+      ? `Math.toRadians(${line.endPoint.degrees ?? 0})`
+      : line.endPoint.heading === "linear"
+        ? `Math.toRadians(${line.endPoint.startDeg ?? 0}), Math.toRadians(${line.endPoint.endDeg ?? 0})`
         : "";
 
-      return `${variableName} = follower.pathBuilder()
-          .addPath(
+  const reverseConfig = line.endPoint.reverse ? "\n          .setReversed()" : "";
+
+  return `.addPath(
             new ${curveType}(
               ${allPoints}
             )
           )
-          .${headingTypeToFunctionName[line.endPoint.heading]}(${headingConfig})${reverseConfig}
+          .${headingTypeToFunctionName[line.endPoint.heading]}(${headingConfig})${reverseConfig}`;
+}
+
+export async function generateJavaCode(
+  startPoint: Point,
+  lines: Line[],
+  exportMode: "full" | "class" | "coordinates" = "class",
+  pathChains: PathChain[] = [],
+): Promise<string> {
+  const linesWithIds = lines.map((line, idx) => ({
+    ...line,
+    id: line.id || `line-${idx + 1}`,
+  }));
+  const lineById = new Map(linesWithIds.map((line) => [line.id!, line]));
+
+  const inputChains =
+    pathChains.length > 0
+      ? pathChains
+      : linesWithIds.map((line, idx) => ({
+          id: line.id!,
+          name: line.name || `Path ${idx + 1}`,
+          color: "#22c55e",
+          lineIds: [line.id!],
+        }));
+
+  const normalizedChains: PathChain[] = inputChains
+    .map((chain, idx) => ({
+      ...chain,
+      id: chain.id || `chain-${idx + 1}`,
+      name: chain.name || `PathChain${idx + 1}`,
+      lineIds: (chain.lineIds || []).filter((id) => lineById.has(id)),
+    }))
+    .filter((chain) => chain.lineIds.length > 0);
+
+  const fieldDeclarations = normalizedChains
+    .map((chain, idx) => {
+      const variableName = sanitizeIdentifier(chain.name, `pathChain${idx + 1}`);
+      return `public PathChain ${variableName};`;
+    })
+    .join("\n    ");
+
+  const pathAssignments = normalizedChains
+    .map((chain, chainIdx) => {
+      const variableName = sanitizeIdentifier(chain.name, `pathChain${chainIdx + 1}`);
+
+      const segmentSnippets = chain.lineIds
+        .map((lineId) => {
+          const line = lineById.get(lineId);
+          if (!line) return null;
+
+          const lineIndex = linesWithIds.findIndex((ln) => ln.id === line.id);
+          const startExpression =
+            lineIndex <= 0
+              ? `new Pose(${startPoint.x.toFixed(3)}, ${startPoint.y.toFixed(3)})`
+              : `new Pose(${linesWithIds[lineIndex - 1].endPoint.x.toFixed(3)}, ${linesWithIds[lineIndex - 1].endPoint.y.toFixed(3)})`;
+
+          return buildPathSegmentCode(line, startExpression);
+        })
+        .filter((segment): segment is string => Boolean(segment));
+
+      return `${variableName} = follower.pathBuilder()
+          ${segmentSnippets.join("\n          ")}
           .build();`;
     })
     .join("\n\n      ");

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,4 +1,4 @@
-import type { Point, Line, Shape, SequenceItem } from "../types";
+import type { Point, Line, Shape, SequenceItem, PathChain } from "../types";
 
 /**
  * File save/load utilities for the visualizer
@@ -10,6 +10,7 @@ export interface SaveData {
   shapes?: Shape[];
   settings?: any;
   sequence?: SequenceItem[];
+  pathChains?: PathChain[];
 }
 
 /**
@@ -20,8 +21,9 @@ export function downloadTrajectory(
   lines: Line[],
   shapes: Shape[],
   sequence?: SequenceItem[],
+  pathChains?: PathChain[],
 ): void {
-  const jsonString = JSON.stringify({ startPoint, lines, shapes, sequence });
+  const jsonString = JSON.stringify({ startPoint, lines, shapes, sequence, pathChains });
   const blob = new Blob([jsonString], { type: "application/json" });
   const linkObj = document.createElement("a");
   const url = URL.createObjectURL(blob);

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,4 +1,4 @@
-import type { Point, Line, Shape, SequenceItem, Settings } from "../types";
+import type { Point, Line, Shape, SequenceItem, Settings, PathChain } from "../types";
 import { writable } from "svelte/store";
 
 export type AppState = {
@@ -7,6 +7,7 @@ export type AppState = {
   shapes: Shape[];
   sequence: SequenceItem[];
   settings: Settings;
+  pathChains: PathChain[];
 };
 
 function deepClone<T>(obj: T): T {


### PR DESCRIPTION
Added exporting as path chains and assigning paths to to path chains
Path chain duplication that copies every path in a selected chain.
Each copied path is inserted immediately after its original in the sequence.
A new duplicated chain is created and populated with those copied paths.
A Duplicate button in the Path Chains controls to trigger this.
<img width="771" height="504" alt="image" src="https://github.com/user-attachments/assets/2f39d868-bd77-4c07-9b42-74fb301e0ee5" />
<img width="864" height="656" alt="image" src="https://github.com/user-attachments/assets/14f1165c-3a4c-4e06-a9aa-edb4008fbfa8" />
